### PR TITLE
Add missing compile flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -239,6 +239,10 @@ else()
 endif()
 
 include(TryAppendCFlags)
+if(SGX)
+  try_append_c_flags(-fPIE)
+endif()
+
 if(MSVC)
   # Keep the following commands ordered lexicographically.
   try_append_c_flags(/W3) # Production quality warning level.


### PR DESCRIPTION
Solves the error:
/linux-sgx/sgx/external/toolset/nix/ld: /linux-sgx/silentdata-defi-enclave/../secp256k1-sgx/build/install/lib/libsecp256k1_t.a(secp256k1.c.o): relocation R_X86_64_32 against `.rodata' can not be used when making a PIE object; recompile with -fPIE
collect2: error: ld returned 1 exit status

By adding the missing compile flag